### PR TITLE
Revert "Prevent segv from rcu_head_delete"

### DIFF
--- a/Test/rcu_head_delete.hpp
+++ b/Test/rcu_head_delete.hpp
@@ -18,18 +18,13 @@ namespace std {
 			rhdp->deleter(obj);
 		}
 
-		static void rcu_head_deleter(T *obj)
-		{
-			delete(obj);
-		}
-
-		void call(D d = rcu_head_deleter)
+		void call(D d = {})
 		{
 			deleter = d;
 			call_rcu(static_cast<rcu_head *>(this), trampoline);
 		}
 
-		void call(rcu_domain &rd, D d = rcu_head_deleter)
+		void call(rcu_domain &rd, D d = {})
 		{
 			deleter = d;
 			rd.call(static_cast<rcu_head *>(this), trampoline);
@@ -46,17 +41,12 @@ namespace std {
 			D()(obj);
 		}
 
-		static void rcu_head_deleter(T *obj)
-		{
-			delete(obj);
-		}
-
-		void call(D d = rcu_head_deleter)
+		void call(D d = {})
 		{
 			call_rcu(static_cast<rcu_head *>(this), trampoline);
 		}
 
-		void call(rcu_domain &rd, D d = rcu_head_deleter)
+		void call(rcu_domain &rd, D d = {})
 		{
 			rd.call(static_cast<rcu_head *>(this), trampoline);
 		}

--- a/Test/rcu_head_derived.cpp
+++ b/Test/rcu_head_derived.cpp
@@ -36,15 +36,13 @@ int main(int argc, char **argv)
 	rcu_barrier();
 
 	std::cout << "Deletion with no rcu_domain\n";
-	fp = new foo;
-	fp->a = 44;
-	fp->call();
+	foo1.a = 44;
+	foo1.call(my_cb);
 	rcu_barrier();
 
 	std::cout << "Deletion with rcu_signal rcu_domain\n";
-	fp = new foo;
-	fp->a = 45;
-	fp->call(rs);
+	foo1.a = 45;
+	foo1.call(rs, my_cb);
 	rs.barrier();
 
 	return 0;


### PR DESCRIPTION
This reverts commit 26fe68a583e24ce0ecbe808c3184a4b14a1d78bb.

`make -C Test` was broken by the above commit; reverting it fixes the breakage.
I'm confident that the original commit was not fixing anything.

The breakage in current master looks like this:
```
g++ -g -std=c++1z -I/usr/local/Cellar/userspace-rcu/0.9.1/include -L/usr/local/Cellar/userspace-rcu/0.9.1/lib -o rcu_head_delete rcu_head_delete.cpp -lpthread -lurcu -lurcu-signal
In file included from rcu_head_delete.cpp:4:
./rcu_head_delete.hpp:54:15: error: no viable conversion from 'void (foo *)' to 'std::__1::default_delete<foo>'
                void call(D d = rcu_head_deleter)
                            ^   ~~~~~~~~~~~~~~~~
rcu_head_delete.cpp:21:2: note: in instantiation of default function argument expression for 'call<foo,
      std::__1::default_delete<foo> >' required here
        fp->call();
        ^
```

(plus a few more screenfuls of similar errors from the other test cases)