### PR TITLE
Make rcu_domain a concept instead of a polymorphic base class.

### DIFF
--- a/Test/ajodwyer/rcu.hpp
+++ b/Test/ajodwyer/rcu.hpp
@@ -26,7 +26,8 @@ namespace std {
             ::call_rcu(static_cast<rcu_head *>(this), trampoline);
         }
 
-        void retire(rcu_domain &rd, D d = {})
+        template<class RcuDomain>
+        void retire(RcuDomain& rd, D d = {})
         {
             deleter = std::move(d);
             rd.retire(static_cast<rcu_head *>(this), trampoline);
@@ -51,7 +52,8 @@ namespace std {
             ::call_rcu(static_cast<rcu_head *>(this), trampoline);
         }
 
-        void retire(rcu_domain &rd, D = {})
+        template<class RcuDomain>
+        void retire(RcuDomain& rd, D = {})
         {
             rd.retire(static_cast<rcu_head *>(this), trampoline);
         }

--- a/Test/ajodwyer/test2.cpp
+++ b/Test/ajodwyer/test2.cpp
@@ -12,7 +12,7 @@ struct foo: public std::rcu_obj_base<foo> {
 int main(int argc, char **argv)
 {
     struct foo *fp = new struct foo;
-    std::rcu_signal rs;
+    rcu_domain_signal rs;
 
     printf("%zu %zu %zu\n", sizeof(rcu_head), sizeof(std::rcu_obj_base<foo>), sizeof(foo));
 

--- a/Test/ajodwyer/test3.cpp
+++ b/Test/ajodwyer/test3.cpp
@@ -18,7 +18,7 @@ struct foo foo1;
 
 int main(int argc, char **argv)
 {
-    std::rcu_signal rs;
+    rcu_domain_signal rs;
 
     printf("%zu %zu %zu\n", sizeof(rcu_head), sizeof(std::rcu_obj_base<foo, void(*)(foo*)>), sizeof(foo));
 

--- a/Test/domains/rcu_domain.hpp
+++ b/Test/domains/rcu_domain.hpp
@@ -3,24 +3,61 @@
 extern "C" struct rcu_head;
 
 namespace std {
-    class rcu_domain {
+namespace rcu {
+    // See Lawrence Crowl's P0260 "C++ Concurrent Queues" for this API's rationale.
+    // Basically, there is an implicit concept RcuDomain that is satisfied by any
+    // domain providing these functions; rcu_domain_base is a reification of that
+    // concept into a classical polymorphic class; rcu_domain_wrapper<D> is a
+    // classical polymorphic class derived from rcu_domain_base which implements
+    // the same semantics as class D (which must satisfy the RcuDomain concept).
+    // http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2016/p0260r0.html#Binary
+    //
+    class rcu_domain_base {
     public:
-	constexpr explicit rcu_domain() noexcept { };
-	rcu_domain(const rcu_domain&) = delete;
-	rcu_domain(rcu_domain&&) = delete;
-	rcu_domain& operator=(const rcu_domain&) = delete;
-	rcu_domain& operator=(rcu_domain&&) = delete;
+	rcu_domain_base() noexcept = default;
+	rcu_domain_base(const rcu_domain_base&) = delete;
+	virtual ~rcu_domain_base() = default;
+
+	virtual bool register_thread_needed() const noexcept = 0;
 	virtual void register_thread() = 0;
 	virtual void unregister_thread() = 0;
-	static constexpr bool register_thread_needed() { return true; }
-	virtual void quiescent_state() noexcept = 0;
 	virtual void thread_offline() noexcept = 0;
 	virtual void thread_online() noexcept = 0;
-	static constexpr bool quiescent_state_needed() { return false; }
+
+	virtual bool quiescent_state_needed() const noexcept = 0;
+	virtual void quiescent_state() noexcept = 0;
+
 	virtual void read_lock() noexcept = 0;
 	virtual void read_unlock() noexcept = 0;
-	virtual void synchronize() noexcept = 0;
+
 	virtual void retire(rcu_head *rhp, void (*cbf)(rcu_head *rhp)) = 0;
+
+	virtual void synchronize() noexcept = 0;
 	virtual void barrier() noexcept = 0;
     };
+
+    template<class Domain>
+    class rcu_domain_wrapper : public virtual rcu_domain_base {
+	Domain *d;
+    public:
+	rcu_domain_wrapper(Domain& d) noexcept : d(&d) {}
+
+	bool register_thread_needed() const noexcept override { return d->register_thread_needed(); }
+	void register_thread() override { d->register_thread(); }
+	void unregister_thread() override { d->unregister_thread(); }
+	void thread_offline() noexcept override { d->thread_offline(); }
+	void thread_online() noexcept override { d->thread_online(); }
+
+	bool quiescent_state_needed() const noexcept override { return d->quiescent_state_needed(); }
+	void quiescent_state() noexcept override { d->quiescent_state(); }
+
+	void read_lock() noexcept override { d->read_lock(); }
+	void read_unlock() noexcept override { d->read_unlock(); }
+
+	void retire(rcu_head *rhp, void (*cbf)(rcu_head *rhp)) override { d->retire(rhp, cbf); }
+
+	void synchronize() noexcept override { d->synchronize(); }
+	void barrier() noexcept override { d->barrier(); }
+    };
+} // namespace rcu
 } // namespace std

--- a/Test/domains/test5.cpp
+++ b/Test/domains/test5.cpp
@@ -16,7 +16,7 @@ void my_func(rcu_head *rhp)
 	std::cout << "Hello World from a callback!\n";
 }
 
-void synchronize_rcu_abstract(std::rcu_domain &p, std::string s)
+void synchronize_rcu_abstract(std::rcu::rcu_domain_base& p, std::string s)
 {
 	std::cout << s << "\n";
 	p.register_thread();
@@ -29,11 +29,11 @@ void synchronize_rcu_abstract(std::rcu_domain &p, std::string s)
 	p.unregister_thread();
 }
 
-extern std::rcu_domain &rb;
-extern std::rcu_domain &rm;
-extern std::rcu_domain &rq;
-extern std::rcu_domain &rs;
-extern std::rcu_domain &rv;
+extern std::rcu::rcu_domain_base& rb;
+extern std::rcu::rcu_domain_base& rm;
+extern std::rcu::rcu_domain_base& rq;
+extern std::rcu::rcu_domain_base& rs;
+extern std::rcu::rcu_domain_base& rv;
 
 int main()
 {

--- a/Test/domains/test5b.cpp
+++ b/Test/domains/test5b.cpp
@@ -1,4 +1,5 @@
 #include "urcu-bp.hpp"
 
-static std::rcu_bp _rb;
-std::rcu_domain &rb = _rb;
+static rcu_domain_bp _rb;
+static std::rcu::rcu_domain_wrapper<decltype(_rb)> _rbw(_rb);
+std::rcu::rcu_domain_base& rb = _rbw;

--- a/Test/domains/test5m.cpp
+++ b/Test/domains/test5m.cpp
@@ -1,4 +1,5 @@
 #include "urcu-mb.hpp"
 
-static std::rcu_mb _rm;
-std::rcu_domain &rm = _rm;
+static rcu_domain_mb _rm;
+static std::rcu::rcu_domain_wrapper<decltype(_rm)> _rmw(_rm);
+std::rcu::rcu_domain_base& rm = _rmw;

--- a/Test/domains/test5q.cpp
+++ b/Test/domains/test5q.cpp
@@ -1,4 +1,5 @@
 #include "urcu-qsbr.hpp"
 
-static std::rcu_qsbr _rq;
-std::rcu_domain &rq = _rq;
+static rcu_domain_qsbr _rq;
+static std::rcu::rcu_domain_wrapper<decltype(_rq)> _rqw(_rq);
+std::rcu::rcu_domain_base& rq = _rqw;

--- a/Test/domains/test5s.cpp
+++ b/Test/domains/test5s.cpp
@@ -1,4 +1,5 @@
 #include "urcu-signal.hpp"
 
-static std::rcu_signal _rs;
-std::rcu_domain &rs = _rs;
+static rcu_domain_signal _rs;
+static std::rcu::rcu_domain_wrapper<decltype(_rs)> _rsw(_rs);
+std::rcu::rcu_domain_base& rs = _rsw;

--- a/Test/domains/test5v.cpp
+++ b/Test/domains/test5v.cpp
@@ -1,4 +1,5 @@
 #include "urcu-rv.hpp"
 
-static std::rcu_rv _rv;
-std::rcu_domain &rv = _rv;
+static rcu_domain_rv _rv;
+static std::rcu::rcu_domain_wrapper<decltype(_rv)> _rvw(_rv);
+std::rcu::rcu_domain_base& rv = _rvw;

--- a/Test/domains/urcu-bp.hpp
+++ b/Test/domains/urcu-bp.hpp
@@ -3,22 +3,23 @@
 #include "rcu_domain.hpp"
 
 #include <urcu-bp.h>
-#define _LGPL_SOURCE
 
-namespace std {
-    class rcu_bp: public rcu_domain {
-    public:
-        void register_thread() { rcu_register_thread(); }
-        void unregister_thread() { rcu_unregister_thread(); }
-        void read_lock() noexcept { rcu_read_lock(); }
-        void read_unlock() noexcept { rcu_read_unlock(); }
-        void synchronize() noexcept { synchronize_rcu(); }
-        void retire(rcu_head *rhp, void (*cbf)(rcu_head *rhp)) { call_rcu(rhp, cbf); }
-        void barrier() noexcept { rcu_barrier(); }
-        void quiescent_state() noexcept { rcu_quiescent_state(); }
-        void thread_offline() noexcept { rcu_thread_offline(); }
-        void thread_online() noexcept { rcu_thread_online(); }
+class rcu_domain_bp {
+public:
+    static constexpr bool register_thread_needed() { return false; }
+    void register_thread() { rcu_register_thread(); }
+    void unregister_thread() { rcu_unregister_thread(); }
+    void thread_offline() noexcept { rcu_thread_offline(); }
+    void thread_online() noexcept { rcu_thread_online(); }
 
-        static constexpr bool register_thread_needed() { return false; }
-    };
-} // namespace std
+    static constexpr bool quiescent_state_needed() { return false; }
+    void quiescent_state() noexcept { rcu_quiescent_state(); }
+
+    void read_lock() noexcept { rcu_read_lock(); }
+    void read_unlock() noexcept { rcu_read_unlock(); }
+
+    void retire(rcu_head *rhp, void (*cbf)(rcu_head *rhp)) { call_rcu(rhp, cbf); }
+
+    void synchronize() noexcept { synchronize_rcu(); }
+    void barrier() noexcept { rcu_barrier(); }
+};

--- a/Test/domains/urcu-bp.hpp
+++ b/Test/domains/urcu-bp.hpp
@@ -7,13 +7,13 @@
 class rcu_domain_bp {
 public:
     static constexpr bool register_thread_needed() { return false; }
-    void register_thread() { rcu_register_thread(); }
-    void unregister_thread() { rcu_unregister_thread(); }
+    void register_thread() {}
+    void unregister_thread() {}
     void thread_offline() noexcept { rcu_thread_offline(); }
     void thread_online() noexcept { rcu_thread_online(); }
 
     static constexpr bool quiescent_state_needed() { return false; }
-    void quiescent_state() noexcept { rcu_quiescent_state(); }
+    void quiescent_state() noexcept {}
 
     void read_lock() noexcept { rcu_read_lock(); }
     void read_unlock() noexcept { rcu_read_unlock(); }

--- a/Test/domains/urcu-mb.hpp
+++ b/Test/domains/urcu-mb.hpp
@@ -2,22 +2,26 @@
 
 #include "rcu_domain.hpp"
 
-#include <urcu.h>
-#define _LGPL_SOURCE
 #define RCU_MB
+#include <urcu.h>
 
-namespace std {
-    class rcu_mb: public rcu_domain {
-    public:
-        void register_thread() { rcu_register_thread(); }
-        void unregister_thread() { rcu_unregister_thread(); }
-        void read_lock() noexcept { rcu_read_lock(); }
-        void read_unlock() noexcept { rcu_read_unlock(); }
-        void synchronize() noexcept { synchronize_rcu(); }
-        void retire(rcu_head *rhp, void (*cbf)(rcu_head *rhp)) { call_rcu(rhp, cbf); }
-        void barrier() noexcept { rcu_barrier(); }
-        void quiescent_state() noexcept { rcu_quiescent_state(); }
-        void thread_offline() noexcept { rcu_thread_offline(); }
-        void thread_online() noexcept { rcu_thread_online(); }
-    };
-} // namespace std
+class rcu_domain_mb {
+public:
+    static constexpr bool register_thread_needed() { return true; }
+    void register_thread() { rcu_register_thread(); }
+    void unregister_thread() { rcu_unregister_thread(); }
+    void thread_offline() noexcept { rcu_thread_offline(); }
+    void thread_online() noexcept { rcu_thread_online(); }
+
+    static constexpr bool quiescent_state_needed() { return false; }
+    void quiescent_state() noexcept { rcu_quiescent_state(); }
+
+    void read_lock() noexcept { rcu_read_lock(); }
+    void read_unlock() noexcept { rcu_read_unlock(); }
+
+    void retire(rcu_head *rhp, void (*cbf)(rcu_head *rhp)) { call_rcu(rhp, cbf); }
+
+    void synchronize() noexcept { synchronize_rcu(); }
+    void barrier() noexcept { rcu_barrier(); }
+
+};

--- a/Test/domains/urcu-mb.hpp
+++ b/Test/domains/urcu-mb.hpp
@@ -14,7 +14,7 @@ public:
     void thread_online() noexcept { rcu_thread_online(); }
 
     static constexpr bool quiescent_state_needed() { return false; }
-    void quiescent_state() noexcept { rcu_quiescent_state(); }
+    void quiescent_state() noexcept {}
 
     void read_lock() noexcept { rcu_read_lock(); }
     void read_unlock() noexcept { rcu_read_unlock(); }

--- a/Test/domains/urcu-qsbr.hpp
+++ b/Test/domains/urcu-qsbr.hpp
@@ -3,21 +3,23 @@
 #include "rcu_domain.hpp"
 
 #include <urcu-qsbr.h>
-#define _LGPL_SOURCE
 
-namespace std {
-    class rcu_qsbr: public rcu_domain {
+class rcu_domain_qsbr {
 public:
-        void register_thread() { rcu_register_thread(); }
-        void unregister_thread() { rcu_unregister_thread(); }
-        void read_lock() noexcept { rcu_read_lock(); }
-        void read_unlock() noexcept { rcu_read_unlock(); }
-        void synchronize() noexcept { synchronize_rcu(); }
-        void retire(rcu_head *rhp, void (*cbf)(rcu_head *rhp)) { call_rcu(rhp, cbf); }
-        void barrier() noexcept { rcu_barrier(); }
-        void quiescent_state() noexcept { rcu_quiescent_state(); }
-        void thread_offline() noexcept { rcu_thread_offline(); }
-        void thread_online() noexcept { rcu_thread_online(); }
-	static constexpr bool quiescent_state_needed() { return true; }
-    };
-} // namespace std
+    static constexpr bool register_thread_needed() { return true; }
+    void register_thread() { rcu_register_thread(); }
+    void unregister_thread() { rcu_unregister_thread(); }
+    void thread_offline() noexcept { rcu_thread_offline(); }
+    void thread_online() noexcept { rcu_thread_online(); }
+
+    static constexpr bool quiescent_state_needed() { return true; }
+    void quiescent_state() noexcept { rcu_quiescent_state(); }
+
+    void read_lock() noexcept { rcu_read_lock(); }
+    void read_unlock() noexcept { rcu_read_unlock(); }
+
+    void retire(rcu_head *rhp, void (*cbf)(rcu_head *rhp)) { call_rcu(rhp, cbf); }
+
+    void synchronize() noexcept { synchronize_rcu(); }
+    void barrier() noexcept { rcu_barrier(); }
+};

--- a/Test/domains/urcu-rv.hpp
+++ b/Test/domains/urcu-rv.hpp
@@ -8,8 +8,6 @@
 #include <iostream>
 #include "rcu_domain.hpp"
 
-namespace std {
-
 thread_local int tl_urcu_rv_tid = -1;
 
 /**
@@ -31,7 +29,7 @@ thread_local int tl_urcu_rv_tid = -1;
  *
  *
  */
-class rcu_rv: public rcu_domain {
+class rcu_domain_rv {
 
     static const int CLPAD = (128/sizeof(uint64_t));
     static const uint64_t NOT_READING = 0xFFFFFFFFFFFFFFFE;
@@ -41,10 +39,10 @@ class rcu_rv: public rcu_domain {
     std::atomic<uint64_t> reclaimerVersion alignas(128) = { 0 };
     std::atomic<uint64_t>* readersVersion alignas(128);
     std::mutex listMutex;
-    std::vector<future<void>> futureList;
+    std::vector<std::future<void>> futureList;
 
 public:
-    rcu_rv(const int maxThreads=32): maxThreads{maxThreads}
+    rcu_domain_rv(const int maxThreads=32): maxThreads{maxThreads}
     {
         readersVersion = new std::atomic<uint64_t>[maxThreads*CLPAD];
         for (int i=0; i < maxThreads; i++) {
@@ -52,7 +50,7 @@ public:
         }
     }
 
-    ~rcu_rv() {
+    ~rcu_domain_rv() {
         delete[] readersVersion;
     }
 
@@ -137,5 +135,7 @@ public:
     void quiescent_state() noexcept { read_lock(); }
     void thread_offline() noexcept { read_unlock(); }
     void thread_online() noexcept { read_lock(); }
+
+    static constexpr bool register_thread_needed() { return true; }
+    static constexpr bool quiescent_state_needed() { return false; }
 };
-} // namespace std

--- a/Test/domains/urcu-rv.hpp
+++ b/Test/domains/urcu-rv.hpp
@@ -132,7 +132,7 @@ public:
         futureList.clear();
     }
 
-    void quiescent_state() noexcept { read_lock(); }
+    void quiescent_state() noexcept {}
     void thread_offline() noexcept { read_unlock(); }
     void thread_online() noexcept { read_lock(); }
 

--- a/Test/domains/urcu-signal.hpp
+++ b/Test/domains/urcu-signal.hpp
@@ -2,22 +2,25 @@
 
 #include "rcu_domain.hpp"
 
-#include <urcu.h>
-#define _LGPL_SOURCE
 #define RCU_SIGNAL
+#include <urcu.h>
 
-namespace std {
-    class rcu_signal: public rcu_domain {
-    public:
-        void register_thread() { rcu_register_thread(); }
-        void unregister_thread() { rcu_unregister_thread(); }
-        void read_lock() noexcept { rcu_read_lock(); }
-        void read_unlock() noexcept { rcu_read_unlock(); }
-        void synchronize() noexcept { synchronize_rcu(); }
-        void retire(rcu_head *rhp, void (*cbf)(rcu_head *rhp)) { call_rcu(rhp, cbf); }
-        void barrier() noexcept { rcu_barrier(); }
-        void quiescent_state() noexcept { rcu_quiescent_state(); }
-        void thread_offline() noexcept { rcu_thread_offline(); }
-        void thread_online() noexcept { rcu_thread_online(); }
-    };
-} // namespace std
+class rcu_domain_signal {
+public:
+    static constexpr bool register_thread_needed() { return true; }
+    void register_thread() { rcu_register_thread(); }
+    void unregister_thread() { rcu_unregister_thread(); }
+    void thread_offline() noexcept { rcu_thread_offline(); }
+    void thread_online() noexcept { rcu_thread_online(); }
+
+    static constexpr bool quiescent_state_needed() { return false; }
+    void quiescent_state() noexcept { rcu_quiescent_state(); }
+
+    void read_lock() noexcept { rcu_read_lock(); }
+    void read_unlock() noexcept { rcu_read_unlock(); }
+
+    void retire(rcu_head *rhp, void (*cbf)(rcu_head *rhp)) { call_rcu(rhp, cbf); }
+
+    void synchronize() noexcept { synchronize_rcu(); }
+    void barrier() noexcept { rcu_barrier(); }
+};

--- a/Test/domains/urcu-signal.hpp
+++ b/Test/domains/urcu-signal.hpp
@@ -14,7 +14,7 @@ public:
     void thread_online() noexcept { rcu_thread_online(); }
 
     static constexpr bool quiescent_state_needed() { return false; }
-    void quiescent_state() noexcept { rcu_quiescent_state(); }
+    void quiescent_state() noexcept {}
 
     void read_lock() noexcept { rcu_read_lock(); }
     void read_unlock() noexcept { rcu_read_unlock(); }

--- a/Test/dshollman/rcu_ptr.hpp
+++ b/Test/dshollman/rcu_ptr.hpp
@@ -13,7 +13,6 @@ namespace std { namespace experimental {
 // (Paul's code would go here)
 
 using rcu_head = ::rcu_head;
-using rcu_domain = ::std::rcu_domain;
 
 void call_rcu(
   rcu_head *_Rhp,
@@ -32,7 +31,7 @@ template <typename _T>
 struct is_rcu_domain {
   // for now, just use is_base_of...
   static constexpr bool value = ::std::is_base_of<
-    rcu_domain, _T
+    ::std::rcu::rcu_domain_base, _T
   >::value;
 };
 

--- a/Test/imuerte/rcu_head_delete.hpp
+++ b/Test/imuerte/rcu_head_delete.hpp
@@ -23,7 +23,8 @@ namespace std {
             });
         }
 
-        void retire(rcu_domain& rd) {
+        template<class RcuDomain>
+        void retire(RcuDomain& rd) {
             rd.retire(this, +[] (rcu_head * rhp) {
                 auto self = static_cast<T*>(rhp);
                 self->get_deleter()(self);

--- a/Test/imuerte/test6.cpp
+++ b/Test/imuerte/test6.cpp
@@ -24,7 +24,7 @@ int main(int argc, char **argv)
 {
     struct bar my_bar;
     struct foo *fp = new struct foo;
-    std::rcu_signal rs;
+    rcu_domain_signal rs;
 
     // First with a normal function.
     fp->a = 42;

--- a/Test/intrusive2/rcu_head_ptr.hpp
+++ b/Test/intrusive2/rcu_head_ptr.hpp
@@ -35,7 +35,8 @@ namespace std {
 			call_rcu(static_cast<rcu_head *>(this), trampoline);
 		}
 
-		void retire(rcu_domain &rd,
+                template<class RcuDomain>
+		void retire(RcuDomain& rd,
 			  void callback_func(T *obj) = nullptr)
 		{
 			this->callback_func = callback_func;

--- a/Test/intrusive2/test8.cpp
+++ b/Test/intrusive2/test8.cpp
@@ -25,7 +25,7 @@ struct foo foo1(42);
 int main(int argc, char **argv)
 {
 	struct foo *fp;
-	std::rcu_signal rs;
+	rcu_domain_signal rs;
 
 	foo1.rh = &foo1;
 	foo1.rh.retire(my_cb);

--- a/Test/rcu_guard.hpp
+++ b/Test/rcu_guard.hpp
@@ -1,3 +1,6 @@
+#pragma once
+
+template<class Domain>
 class rcu_guard {
 public:
     rcu_guard() noexcept
@@ -6,9 +9,8 @@ public:
         ::rcu_read_lock();
     }
 
-    explicit rcu_guard(std::rcu_domain *rd)
+    explicit rcu_guard(Domain& d) : rd(&d)
     {
-        this->rd = rd;
         rd->read_lock();
     }
 
@@ -24,5 +26,5 @@ public:
     }
 
 private:
-    std::rcu_domain *rd;
+    Domain *rd;
 };

--- a/Test/test4.cpp
+++ b/Test/test4.cpp
@@ -1,16 +1,15 @@
-#include <iostream>
 #include "urcu-signal.hpp"
 #include "rcu_guard.hpp"
 
 int main()
 {
-    std::rcu_signal rs;
+    rcu_domain_signal rs;
     rcu_register_thread();
     {
-            rcu_guard rr;
+            rcu_guard<rcu_domain_signal> rr;
     }
     {
-            rcu_guard rrs(&rs);
+            rcu_guard<rcu_domain_signal> rrs(rs);
     }
     rcu_unregister_thread();
 


### PR DESCRIPTION
And provide helpers `std::rcu::rcu_domain_base` and `std::rcu::rcu_domain_wrapper` following the example set by Lawrence Crowl's [P0260R0](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2016/p0260r0.html#Binary).

I believe this accomplishes the same goal as Paul's e9453e11432018d5599e725d825482c515bfd55f but without breaking any existing tests.

Notice that I've renamed `::std::rcu_bp` --> `::rcu_domain_bp` and so on. The move out of `namespace std` indicates that these classes are *not* being proposed for standardization. The renaming to include `_domain` in their class names is just for clarity.

Notice that I've moved `rcu_domain_base` into the `::std::rcu` namespace. This makes its fully qualified name a bit redundant; I'd like to propose removing the redundant `rcu_` from a whole lot of identifiers (e.g. `std::rcu::domain_base`, `std::rcu::obj_base` (although personally I prefer `std::rcu::enable_retire_on_this`), etc). That renaming would be too much for this PR, though.

Fixes #6.